### PR TITLE
Check env in post-autoload-dump

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
         "post-autoload-dump": [
             "Illuminate\\Foundation\\ComposerScripts::postAutoloadDump",
             "@php artisan package:discover --ansi",
-            "@php artisan ide-helper:generate"
+            "@php -r \"if(getenv('APP_ENV') === 'local'){ passthru('php artisan ide-helper:generate'); }\""
         ],
         "post-update-cmd": [
             "@php artisan vendor:publish --tag=laravel-assets --ansi --force"


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Generate IDE helper files only when `APP_ENV` is set to `local`.